### PR TITLE
Fix list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,4 +10,4 @@ get_maven_versions() {
   done
 }
 
-echo $(get_maven_versions) | rev
+get_maven_versions | tac | tr "\n" " "


### PR DESCRIPTION
The `rev` commands reverses all characters in line, it's wasn't working for me. (Arch Linux)
The `tac` command comes from `coreutils` and prints lines in reverse order. Then new line characters are changed to spaces with `tr`. I'm not sure if it works on Windows.