### PR TITLE
fix asdf's java path detection

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # if asdf provides java, then let's use that rather the system one (if at all avail)
 if asdf current java > /dev/null 2>&1 ; then
-	asdf_java_version=$(asdf current java | cut -f1 -d' ')
+	asdf_java_version=$(asdf current java | sed -s 's|\(.*\) \?(.*|\1|g')
 	export JAVA_HOME=$(asdf where java "$asdf_java_version")
 fi


### PR DESCRIPTION
This plugins sets JAVA_HOME based on the current java version in asdf, however the version detection is buggy. There are no spaces between the version and the description in my output. I could change cut to use '(', but I went with the `sed` command suggested in https://github.com/skotchpine/asdf-java/ instead.

```
$ asdf current java
oracle-8.181(set by /home/chris/.tool-versions)
$ asdf current java | cut -f1 -d' '
oracle-8.181(set
$ asdf current java | sed -s 's|\(.*\) \?(.*|\1|g'
oracle-8.181
```