### PR TITLE
Remove -s flag from sed invocation

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # if asdf provides java, then let's use that rather the system one (if at all avail)
 if asdf current java > /dev/null 2>&1 ; then
-	asdf_java_version=$(asdf current java | sed -s 's|\(.*\) \?(.*|\1|g')
+	asdf_java_version=$(asdf current java | sed 's|\(.*\) \?(.*|\1|g')
 	export JAVA_HOME=$(asdf where java "$asdf_java_version")
 fi


### PR DESCRIPTION
sed on Darwin/MacOS does not support this flag and it appears to be
unnecessary.

This addresses #15 