### PR TITLE
Fix sed execution error on macOS

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # if asdf provides java, then let's use that rather the system one (if at all avail)
 if asdf current java > /dev/null 2>&1 ; then
-	asdf_java_version=$(asdf current java | sed -s 's|\(.*\) \?(.*|\1|g')
+	asdf_java_version=$(asdf current java | cut -d '(' -f 1)
 	export JAVA_HOME=$(asdf where java "$asdf_java_version")
 fi


### PR DESCRIPTION
Before:

	  asdf current java | sed -s 's|\(.*\) \?(.*|\1|g'
	sed: illegal option -- s
	usage: sed script [-Ealn] [-i extension] [file ...]
	       sed [-Ealn] [-i extension] [-e script] ... [-f script_file] ... [file ...]

After:

	  asdf current java | cut -d '(' -f 1
	oracle-8.181

Hope this helps! :)