### PR TITLE
Fix JAVA_HOME when using adsf-maven on macOS

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,4 +3,12 @@
 if asdf current java > /dev/null 2>&1 ; then
 	asdf_java_version=$(asdf current java | sed -s 's|\(.*\) \?(.*|\1|g')
 	export JAVA_HOME=$(asdf where java "$asdf_java_version")
+	case "$(uname -s)" in
+		Linux)
+			export JAVA_HOME=$(asdf where java "$asdf_java_version") ;;
+		Darwin)
+			export JAVA_HOME=$(asdf where java "$asdf_java_version")"/Contents/Home" ;;
+		*) 
+			export JAVA_HOME=$(asdf where java "$asdf_java_version") ;;
+	esac
 fi


### PR DESCRIPTION
When installing Java on macOS its bin path is not directly at the installed location as on Linux.

This PR take this in consideration when trying to set the JAVA_HOME environment variable.