### PR TITLE
Run tests against branch/PR instead master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test maven https://github.com/skotchpine/asdf-maven.git
+script: asdf plugin-test maven $TRAVIS_BUILD_DIR
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh


### PR DESCRIPTION
Use Travis variables to pass the location where relevant code (i.e. the
branch/PR being tested) is checked out on the worker instead of passing
repo master URL to `plugin-test` command.

Closes #12